### PR TITLE
Remove unnecessary environment variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ jobs:
       run: pip install pytest-github-actions-annotate-failures
 
     - run: pytest
-      env:
-        PYTEST_PLUGINS: pytest_github_actions_annotate_failures
 ```
 
 ## Screenshot


### PR DESCRIPTION
It's not necessary to set the `PYTEST_PLUGINS` environment variable, the plugin is loaded anyway. This can be observed [here](https://github.com/relekang/python-semantic-release/runs/659429019?check_suite_focus=true).