### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,19 +9,24 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
         pytest-version: [4.6.11, 5.4.3]
 
         exclude:
           # pytest 5.x.x doesn't support Python 2.7
-          - python-version: 2.7
+          - os: ubuntu-latest
+            python-version: 2.7
+            pytest-version: 5.4.3
+          - os: windows-latest
+            python-version: 2.7
             pytest-version: 5.4.3
 
-    name: Python ${{ matrix.python-version }}, pytest ${{ matrix.pytest-version }}
+    runs-on: ${{ matrix.os }}
+
+    name: ${{ matrix.os }}, Python ${{ matrix.python-version }}, pytest ${{ matrix.pytest-version }}
     steps:
     - uses: actions/checkout@v2
 

--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -35,7 +35,13 @@ def pytest_runtest_makereport(item, call):
         workspace = os.environ.get("GITHUB_WORKSPACE")
         if workspace:
             full_path = os.path.abspath(filesystempath)
-            rel_path = os.path.relpath(full_path, workspace)
+            try:
+                rel_path = os.path.relpath(full_path, workspace)
+            except ValueError:
+                # os.path.relpath() will raise ValueError on Windows
+                # when full_path and workspace have different mount points.
+                # https://github.com/utgwkk/pytest-github-actions-annotate-failures/issues/20
+                rel_path = filesystempath
             if not rel_path.startswith(".."):
                 filesystempath = rel_path
 


### PR DESCRIPTION
issue: #20
`rel_path` will fall back to `filesystempath` when `os.path.relpath(...)` raises ValueError (occurs on Windows)