### PR TITLE
Handle test failures without a line number

### DIFF
--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -49,8 +49,9 @@ def pytest_runtest_makereport(item, call):
             if not rel_path.startswith(".."):
                 filesystempath = rel_path
 
-        # 0-index to 1-index
-        lineno += 1
+        if lineno is not None:
+            # 0-index to 1-index
+            lineno += 1
 
         # get the name of the current failed test, with parametrize info
         longrepr = report.head_line or item.name


### PR DESCRIPTION
This can happen with Pytest plugins such as pytest-mypy which emits test
failures (type checking errors) differently than Pytest normally does for
regular unit tests.

The errors will instead be reported against the file as a whole.

Fixes #46.