### PR TITLE
add longrepr from plugin tests

### DIFF
--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -57,12 +57,14 @@ def pytest_runtest_makereport(item, call):
         longrepr = report.head_line or item.name
 
         # get the error message and line number from the actual error
-        try:
+        if hasattr(report.longrepr, "reprcrash"):
             longrepr += "\n\n" + report.longrepr.reprcrash.message
             lineno = report.longrepr.reprcrash.lineno
-
-        except AttributeError:
-            pass
+        elif isinstance(report.longrepr, tuple):
+            _, lineno, message = report.longrepr
+            longrepr += "\n\n" + message
+        elif isinstance(report.longrepr, str):
+            longrepr += "\n\n" + report.longrepr
 
         print(
             _error_workflow_command(filesystempath, lineno, longrepr), file=sys.stderr


### PR DESCRIPTION
According to the [pytest reference](https://docs.pytest.org/en/7.1.x/reference/reference.html#id61) `report.longrepr` can be either a an object holding a `reprcrash`, a tuple containing `filename` `linenumber` and `message` in the respective order or a plain string containing a raw message.

The latter is the way plugins like `pytest-flake8` or `pytest-mypy` Create their error messages.  I propose adding the full context there, as only the `report.head_line` or `item.name` can lead to [rather confusing outcomes](https://github.com/flairNLP/flair/pull/2851/commits/99021b6c2ae83612724e1633ef6386b03c5b08b8)

I guess it would be even nicer to create multiple annotations per error, but then this plugin's code base would be too dependent on certain other plugins. Having the errors listed at the start of the file should be enough.
