### PR TITLE
ci: add dependabot for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,6 @@ version: 2
 updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
-     directory: "/"
-     schedule:
-       interval: "weekly"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+     directory: "/"
+     schedule:
+       interval: "weekly"


### PR DESCRIPTION
This will keep up the Actions with PRs when they update, and since April 2022 it keeps the same style too (`v2` only gets updates to `v3`, and not `v3.0.0`)!