### PR TITLE
fix(setup): add python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     url="https://github.com/utgwkk/pytest-github-actions-annotate-failures",
     license="MIT",
     classifiers=["Framework :: Pytest",],
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
     packages=find_packages(),
     entry_points={
         "pytest11": [


### PR DESCRIPTION
This will ensure Python versions can be elegantly dropped in the future without breaking usage from the old Python versions.