### PR TITLE
fix: Reference the correct line number in third-party exceptions

### DIFF
--- a/plugin_test.py
+++ b/plugin_test.py
@@ -78,7 +78,7 @@ def test_annotation_third_party_exception(testdir):
     )
 
     testdir.makepyfile(
-        f"""
+        """
         import pytest
         from my_module import fn
         pytest_plugins = 'pytest_github_actions_annotate_failures'

--- a/pytest_github_actions_annotate_failures/plugin.py
+++ b/pytest_github_actions_annotate_failures/plugin.py
@@ -59,7 +59,12 @@ def pytest_runtest_makereport(item, call):
         # get the error message and line number from the actual error
         if hasattr(report.longrepr, "reprcrash"):
             longrepr += "\n\n" + report.longrepr.reprcrash.message
-            lineno = report.longrepr.reprcrash.lineno
+            traceback_entries = report.longrepr.reprtraceback.reprentries
+            if len(traceback_entries) > 1:
+                # Handle third-party exceptions
+                lineno = traceback_entries[0].reprfileloc.lineno
+            else:
+                lineno = report.longrepr.reprcrash.lineno
         elif isinstance(report.longrepr, tuple):
             _, lineno, message = report.longrepr
             longrepr += "\n\n" + message


### PR DESCRIPTION
Closes https://github.com/utgwkk/pytest-github-actions-annotate-failures/issues/59
